### PR TITLE
Patches to Glow AutoSuggest widget and dragdrop module

### DIFF
--- a/src/dragdrop/dragdrop.js
+++ b/src/dragdrop/dragdrop.js
@@ -1173,8 +1173,8 @@
 				if (this.dropTargets) {
 					this._mousePos = { x: e.pageX, y: e.pageY };
 				}
-				// check for IE mouseup outside of page boundary
-				if(_ie && e.nativeEvent.button == 0) {
+				// check for mouseup outside of page boundary in IE with document mode less than 9
+				if(_ie && e.nativeEvent.button == 0 && !(document.documentMode >= 9)) {
 					this._releaseElement(e);
 					return false;
 				};

--- a/src/widgets/autosuggest/autosuggest.js
+++ b/src/widgets/autosuggest/autosuggest.js
@@ -432,11 +432,11 @@
 						break;
 					case 'ESC':
     					// If set then return to the value originally entered by the user
-    					if (that._original) {
-    					    that.inputElement.val(that._original);
-    						that._value = that._original;
-    						valueChanged(that, true);
-    					}
+						if (that._original) {
+							that.inputElement.val(that._original);
+							that._value = that._original;
+							valueChanged(that, true);
+						}
 						that.hide();
 						return false;
 					case 'DEL':

--- a/src/widgets/autosuggest/autosuggest.js
+++ b/src/widgets/autosuggest/autosuggest.js
@@ -431,10 +431,12 @@
 						}
 						break;
 					case 'ESC':
-						// return to the value originally entered by the user
-						that.inputElement.val(that._original);
-						that._value = that._original;
-						valueChanged(that, true);
+    					// If set then return to the value originally entered by the user
+    					if (that._original) {
+    					    that.inputElement.val(that._original);
+    						that._value = that._original;
+    						valueChanged(that, true);
+    					}
 						that.hide();
 						return false;
 					case 'DEL':


### PR DESCRIPTION
## AutoSuggest

Fixes issue were pressing escape after focusing on input element, but without entering text, caused input to be populated with 'undefined'.
## dragdrop

Altered condition to target only IE versions other than those in version 9 or higher rendering mode for 'mouseup outside of page boundary' fix. In IE9 this is unnecessary and the call to _releaseElement interrupts the drag.
