### PR TITLE
decodeJson should use JSON.parse() when available

### DIFF
--- a/src/data/data.js
+++ b/src/data/data.js
@@ -358,6 +358,14 @@
 					throw new Error("glow.data.decodeJson: cannot decode item");
 				}
 
+				// If JSON.parse() is available use that instead of eval().
+				// options that are passed to decodeJson() are only safety
+				// guarantees which are automatically handled with JSON.parse(),
+				// hence return immediately without acknowledging the options.
+
+				if(window.JSON && window.JSON.parse)
+					return window.JSON.parse(text);
+
 				options = options || {};
 				options.safeMode = options.safeMode || false;
 


### PR DESCRIPTION
Currently, the decodeJSON() method in data.js does not use JSON.parse(), even when
available. This is possibly because at the point this library was written native parsing did
not exist, but now most modern browsers have support for it.

Using eval() triggers potentially leak-like behavior as it creates a new script context which
is kept around during the lifespan of the application. (for purposes of making it debuggable, 
as one reason for this behavior) This change prevents this, which is crucial for memory
constrained platforms like TV/STB/BDPs.
